### PR TITLE
Add debug logs and setup script

### DIFF
--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install dependencies for developing claude-code-action
+
+NODE_VERSION=18
+BUN_VERSION=1.2.11
+
+# Ensure basic tools
+sudo apt-get update && sudo apt-get install -y curl git
+
+# Install Node.js
+curl -fsSL https://deb.nodesource.com/setup_$NODE_VERSION.x | sudo -E bash -
+sudo apt-get install -y nodejs
+
+# Install Bun runtime
+curl -fsSL https://bun.sh/install | bash -s "$BUN_VERSION"
+
+export BUN_INSTALL="$HOME/.bun"
+export PATH="$BUN_INSTALL/bin:$PATH"
+
+# Install project dependencies
+bun install
+
+# Optional: install Claude Code CLI globally for testing
+npm install -g @anthropic-ai/claude-code@^1.0.2
+
+# Install git hooks
+bun run scripts/install-hooks.sh
+
+echo "Setup complete!"

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -14,7 +14,7 @@ curl -fsSL https://deb.nodesource.com/setup_$NODE_VERSION.x | sudo -E bash -
 sudo apt-get install -y nodejs
 
 # Install Bun runtime
-curl -fsSL https://bun.sh/install | bash -s "$BUN_VERSION"
+curl -fsSL https://bun.sh/install | bash -s "bun-v$BUN_VERSION"
 
 export BUN_INSTALL="$HOME/.bun"
 export PATH="$BUN_INSTALL/bin:$PATH"

--- a/src/mcp/github-file-ops-server.ts
+++ b/src/mcp/github-file-ops-server.ts
@@ -37,6 +37,11 @@ const REPO_OWNER = process.env.REPO_OWNER;
 const REPO_NAME = process.env.REPO_NAME;
 const BRANCH_NAME = process.env.BRANCH_NAME;
 
+console.log("[github-file-ops] Starting server...");
+console.log(`[github-file-ops] REPO_OWNER: ${REPO_OWNER}`);
+console.log(`[github-file-ops] REPO_NAME: ${REPO_NAME}`);
+console.log(`[github-file-ops] BRANCH_NAME: ${BRANCH_NAME}`);
+
 if (!REPO_OWNER || !REPO_NAME || !BRANCH_NAME) {
   console.error(
     "Error: REPO_OWNER, REPO_NAME, and BRANCH_NAME environment variables are required",
@@ -232,6 +237,7 @@ server.tool(
         ],
       };
     } catch (error) {
+      console.error("[github-file-ops] commit_files error:", error);
       return {
         content: [
           {
@@ -423,6 +429,7 @@ server.tool(
         ],
       };
     } catch (error) {
+      console.error("[github-file-ops] delete_files error:", error);
       return {
         content: [
           {
@@ -439,6 +446,9 @@ server.tool(
 async function runServer() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
+  console.log(
+    `[github-file-ops] Server running for ${REPO_OWNER}/${REPO_NAME} on branch ${BRANCH_NAME}`,
+  );
   process.on("exit", () => {
     server.close();
   });


### PR DESCRIPTION
## Summary
- add startup debug logs to github-file-ops server
- log errors on commit/delete operations
- show message when server is running
- add setup-dev.sh helper for installing dependencies

## Testing
- `bun test` *(fails: Cannot find module '@actions/core')*